### PR TITLE
Usuários inativos precisam de links 

### DIFF
--- a/siw.php
+++ b/siw.php
@@ -19,18 +19,19 @@ if ($_GET["artigo_titulo"]) {
 		//Verifica se usuário está bloqueado e encerra loop em caso positivo
 		if (isset($user['users'][0]['blockid']) AND !isset($user['users'][0]['blockpartial'])) {
 			$block = TRUE;
-			echo $list['name']." <small>(bloqueado)</small><br>";
+			echo $list['name']." <small>(bloqueado)</small>";
 			continue;
 		}
 		
-		//Verifica se usuário está inativo e encerra loop em caso positivo
+		//Retorna link para envio de aviso
+		echo "<a target='_blank' href='https://pt.wikipedia.org/w/index.php?title=User_talk:".urlencode($list['name'])."&action=edit&section=new&preload=Predefini%C3%A7%C3%A3o:Aviso-ESR-SIW/Preload&preloadparams%5b%5d=".urlencode(trim($_GET["artigo_titulo"]))."&preloadparams%5b%5d='>".$list['name']."</a>";
+
+		//Verifica se usuário está inativo e comenta isso ao lado do nome dele se positivo
 		if ((date("U", strtotime($user['usercontribs'][0]['timestamp'])) + 7776000) < time()) {
-			echo $list['name']." <small>(inativo)</small><br>";
-			continue;
+			echo $list['name']." <small>(inativo)</small>";
 		}
 
-		//Retorna link para envio de aviso
-		echo "<a target='_blank' href='https://pt.wikipedia.org/w/index.php?title=User_talk:".urlencode($list['name'])."&action=edit&section=new&preload=Predefini%C3%A7%C3%A3o:Aviso-ESR-SIW/Preload&preloadparams%5b%5d=".urlencode(trim($_GET["artigo_titulo"]))."&preloadparams%5b%5d='>".$list['name']."</a><br>";
+		echo "<br>";
 	}
 }
 

--- a/siw.php
+++ b/siw.php
@@ -8,10 +8,10 @@ if ($_GET["artigo_titulo"]) {
 	echo "Editores do artigo <b>".trim($_GET["artigo_titulo"])."</b>:<br><small>Inativo: +90 dias</small><br><br>";
 
 	//Coleta nome dos usuários não-bot que editaram o artigo
-	$artigo = pos(json_decode(file_get_contents("https://pt.wikipedia.org/w/api.php?action=query&format=json&prop=contributors&titles=".urlencode(trim($_GET["artigo_titulo"]))."&pcexcluderights=bot&pclimit=max"), true)['query']['pages'])['contributors'];
+	$editores_artigo = pos(json_decode(file_get_contents("https://pt.wikipedia.org/w/api.php?action=query&format=json&prop=contributors&titles=".urlencode(trim($_GET["artigo_titulo"]))."&pcexcluderights=bot&pclimit=max"), true)['query']['pages'])['contributors'];
 
 	//Loop de verificação dos usuários
-	foreach ($artigo as $list) {
+	foreach ($editores_artigo as $list) {
 
 		//Coleta informações do usuário
 		$user = json_decode(file_get_contents("https://pt.wikipedia.org/w/api.php?action=query&format=json&list=users%7Cusercontribs&usprop=blockinfo&uclimit=1&ususers=".urlencode($list['name'])."&ucuser=".urlencode($list['name'])), true)['query'];

--- a/siw.php
+++ b/siw.php
@@ -2,13 +2,13 @@
 echo "<pre>";
 
 //Verifica se alguma página foi informada
-if ($_GET["nome"]) {
+if ($_GET["artigo_titulo"]) {
 
 	//Introdução da ferramenta
-	echo "Editores do artigo <b>".trim($_GET["nome"])."</b>:<br><small>Inativo: +90 dias</small><br><br>";
+	echo "Editores do artigo <b>".trim($_GET["artigo_titulo"])."</b>:<br><small>Inativo: +90 dias</small><br><br>";
 
 	//Coleta nome dos usuários não-bot que editaram o artigo
-	$artigo = pos(json_decode(file_get_contents("https://pt.wikipedia.org/w/api.php?action=query&format=json&prop=contributors&titles=".urlencode(trim($_GET["nome"]))."&pcexcluderights=bot&pclimit=max"), true)['query']['pages'])['contributors'];
+	$artigo = pos(json_decode(file_get_contents("https://pt.wikipedia.org/w/api.php?action=query&format=json&prop=contributors&titles=".urlencode(trim($_GET["artigo_titulo"]))."&pcexcluderights=bot&pclimit=max"), true)['query']['pages'])['contributors'];
 
 	//Loop de verificação dos usuários
 	foreach ($artigo as $list) {
@@ -30,13 +30,13 @@ if ($_GET["nome"]) {
 		}
 
 		//Retorna link para envio de aviso
-		echo "<a target='_blank' href='https://pt.wikipedia.org/w/index.php?title=User_talk:".urlencode($list['name'])."&action=edit&section=new&preload=Predefini%C3%A7%C3%A3o:Aviso-ESR-SIW/Preload&preloadparams%5b%5d=".urlencode(trim($_GET["nome"]))."&preloadparams%5b%5d='>".$list['name']."</a><br>";
+		echo "<a target='_blank' href='https://pt.wikipedia.org/w/index.php?title=User_talk:".urlencode($list['name'])."&action=edit&section=new&preload=Predefini%C3%A7%C3%A3o:Aviso-ESR-SIW/Preload&preloadparams%5b%5d=".urlencode(trim($_GET["artigo_titulo"]))."&preloadparams%5b%5d='>".$list['name']."</a><br>";
 	}
 }
 
 //Formulário de submissão do nome do artigo
 ?><br>
 <form action="/alberobot/siw.php" method="get">
-  <input type="text" placeholder="Nome do artigo" name="nome">
+  <input type="text" placeholder="Nome do artigo" name="artigo_titulo">
   <input type="submit">
 </form>


### PR DESCRIPTION
Fazendo com que o loop de verificação de usuário não seja encerrado antes da criação do link, no caso dos usuários inativos. Os bloqueados continuarão sem receber links, por razão óbvia.